### PR TITLE
Candidate fuzzy filtering

### DIFF
--- a/durden/gconf.lua
+++ b/durden/gconf.lua
@@ -266,6 +266,7 @@ local defaults = {
 	lbar_seltextstr = "\\#ffffff ",
 	lbar_seltextbg = {0x44, 0x66, 0x88},
 	lbar_itemspace = 10,
+	lbar_fltfun = "prefix",
 
 -- binding bar
 	bind_waittime = 30,

--- a/durden/menu.lua
+++ b/durden/menu.lua
@@ -90,16 +90,20 @@ local function flt_ptn(val, instr)
 end
 
 function flt_fuzzy(val, instr)
-	local last_pos = 0
-	for i=1,#instr do
-		local ch = string.lower(string.sub(instr, i, i))
-		local pos = string.find(string.lower(val), ch, last_pos + 1)
+	local last_pos = 0;
+	local i = string.utf8forward(instr, 0);
+	while i <= #instr do
+		local next_i = string.utf8forward(instr, i);
+		local ch = string.lower(string.sub(instr, i, next_i - 1));
+		local pos = string.find(string.lower(val), ch, last_pos + 1);
 
 		if (not pos) then
 			return false;
 		else
-			last_pos = pos
+			last_pos = pos;
 		end
+
+		i = next_i;
 	end
 
 	return true;
@@ -385,14 +389,19 @@ local function update_menu(ctx, instr, lastv, inp_st)
 
 				local dist = 0;
 				local last_pos = 0;
-				for i=1,#instr do
-					local ch = string.sub(string.lower(instr), i, i);
+				local i = string.utf8forward(instr, 0);
+				while i <= #instr do
+					local next_i = string.utf8forward(instr, i);
+					local ch = string.lower(string.sub(instr, i, next_i - 1));
 					local pos = string.find(string.lower(val), ch, last_pos + 1);
+
 					if (not pos) then
 						break;
 					end
+
 					dist = dist + (pos - last_pos);
 					last_pos = pos;
+					i = next_i;
 				end
 				return dist;
 			end;

--- a/durden/menu.lua
+++ b/durden/menu.lua
@@ -105,6 +105,11 @@ function flt_fuzzy(val, instr)
 	return true;
 end
 
+local flt_lut = {
+["prefix"] = flt_prefix,
+["fuzzy"] = flt_fuzzy,
+};
+
 local function run_hook(path)
 	if (not menu_hook) then
 		return true;
@@ -287,7 +292,7 @@ local function update_menu(ctx, instr, lastv, inp_st)
 -- special case, control character
 	local res = {};
 	local lstr = string.len(instr);
-	local flt_fun = flt_prefix;
+	local flt_fun = flt_lut[gconfig_get("lbar_fltfun")];
 	ctx.subst = false;
 
 	if (lstr > 0) then
@@ -301,12 +306,18 @@ local function update_menu(ctx, instr, lastv, inp_st)
 			instr = string.sub(instr, 3);
 
 -- only one? substitute with commands
-		elseif(string.sub(instr, 1, 1) == "%") then
+		elseif (string.sub(instr, 1, 1) == "%") then
 			ctx.subst = true;
 			for k,v in pairs(sort_lut) do
 				table.insert(res, k);
 			end
+		elseif (string.sub(instr, 1, 1) == "~") then
+			flt_fun = flt_fuzzy;
 		end
+	end
+
+	if (flt_fun == flt_fuzzy) then
+		sort_mode = "fuzzy_relevance"
 	end
 
 -- generate the subset of fields from the expected range

--- a/durden/menus/global/hud.lua
+++ b/durden/menus/global/hud.lua
@@ -58,4 +58,13 @@ return {
 			gconfig_set("lbar_caret_col", tbl);
 		end,
 	},
+	{
+		name = "filter_function",
+		label = "Filter Function",
+		kind = "value",
+		description = "Change the default candidate filtering function",
+		set = {"prefix", "fuzzy"},
+		initial = function() return gconfig_get("lbar_fltfun"); end,
+		handler = function(ctx, val) gconfig_set("lbar_fltfun", val); end
+	}
 };


### PR DESCRIPTION
Implement simple fuzzy filter for HUD candidates.
Also provides sort function, which will sort candidates
by listing best matches first.

Also provides configuration value for default filtering function.
Currently only choices are ­`prefix` and `fuzzy`, since pattern
filter may conflict with special input commands such as `%`.

**Example:**
For given set: `Visual Tools Statusbar Titlebar HUD Terminal System`
Typing out `trm` would match only `Terminal`.
Typing out `ss` would match `System Statusbar Workspace`.