### PR TITLE
Consistent candidate filtering

### DIFF
--- a/durden/suppl.lua
+++ b/durden/suppl.lua
@@ -324,28 +324,6 @@ function table.filter(tbl, filter_fn, ...)
 	return res;
 end
 
-function table.i_subsel(table, label, field)
-	local res = {};
-	local ll = label and string.lower(label) or "";
-	local i = 1;
-
-	for k,v in ipairs(table) do
-		local match = field and v[field] or v;
-		if (type(match) ~= "string") then
-			warning(string.format("invalid entry(%s,%s) in table subselect",
-				v.name and v.name or "[no name]", field));
-			break;
-		end
-		match = string.lower(match);
-		if (string.len(ll) == 0 or string.sub(match, 1, string.len(ll)) == ll) then
-			res[i] = v;
-			i = i + 1;
-		end
-	end
-
-	return res;
-end
-
 function suppl_strcol_fmt(str, sel)
 	local hv = util.hash(str);
 	return HC_PALETTE[(hv % #HC_PALETTE) + 1];

--- a/durden/suppl.lua
+++ b/durden/suppl.lua
@@ -303,6 +303,27 @@ function table.insert_unique_i(tbl, i, v)
 	end
 end
 
+--
+-- Extract subset of array-like table using
+-- given filter function
+--
+-- Accepts table and filter function.
+-- Input table is not modified in process.
+-- Rest of arguments are passed to filter
+-- function.
+--
+function table.filter(tbl, filter_fn, ...)
+	local res = {};
+
+	for _,v in ipairs(tbl) do
+		if (filter_fn(v, ...) == true) then
+			table.insert(res, v);
+		end
+	end
+
+	return res;
+end
+
 function table.i_subsel(table, label, field)
 	local res = {};
 	local ll = label and string.lower(label) or "";


### PR DESCRIPTION
Currently HUD uses different procedures for filtering menu candidates and input set candidates.

This PR provides more generic subset filtering function and provides consistent behavior for HUD candidate filtering. 

Previous `table.i_subsel` function is removed, as it's not used anywhere else and the new `table.filter` is more generic replacement for it.

I ran into uncertainity when implementing free-form text input with optional completion set (example: `/Global/Open/Media URL`). For this case, I chose to use forced prefix filtering, to avoid accidental completion of input strings that are unique, but similar to candidates.