### PR TITLE
ui_sbar_item shader: fix error C1105: cannot call a non-function

### DIFF
--- a/durden/shaders/ui/sbar_item.lua
+++ b/durden/shaders/ui/sbar_item.lua
@@ -7,14 +7,14 @@ return {
 [[
 	uniform sampler2D map_tu0;
 	uniform float factor;
-	uniform float mix;
+	uniform float mix_u;
 	uniform vec3 col;
 	varying vec2 texco;
 
 	void main()
 	{
 		vec4 txcol = texture2D(map_tu0, texco);
-		vec3 bc = mix(col, txcol.rgb, mix);
+		vec3 bc = mix(col, txcol.rgb, mix_u);
 		gl_FragColor = vec4(bc.rgb * factor, txcol.a);
 	}
 ]],
@@ -34,7 +34,7 @@ return {
 		high = 1.0
 		},
 -- use static color or override?
-		mix = {
+		mix_u = {
 		label = 'Mix',
 		utype = 'f',
 		default = 1.0,


### PR DESCRIPTION
Hello,
First of all, many thanks for this very interesting project!

I wasn't able to start durden because of one fragment shader which failed on link stage.
I'm using Nvidia driver 450.66.

Logs :
```
Xorg running, switching to arcan_sdl
Stage:fragment
Error:0(21) : error C1105: cannot call a non-function

:Source:		#ifdef GL_ES
			#ifdef GL_FRAGMENT_PRECISION_HIGH
				precision highp float;
			#else
				precision mediump float;
			#endif
		#else
			#define lowp
			#define mediump
			#define highp
		#endif
		uniform sampler2D map_tu0;
	uniform float factor;
	uniform float mix;
	uniform vec3 col;
	varying vec2 texco;

	void main()
	{
		vec4 txcol = texture2D(map_tu0, texco);
		vec3 bc = mix(col, txcol.rgb, mix);
		gl_FragColor = vec4(bc.rgb * factor, txcol.a);
	}

ui_sbar_item shader failed on link-vertex stage:
ui_sbar_item shader failed on link-fragment stage:
shader_uniform(), shader (0) failed	to activate.
shader_uniform(), shader (0) failed	to activate.
shader_uniform(), shader (0) failed	to activate.
crashdump requested but (/home/adonis/.arcan/resources/logs/crash_1111_110451.lua) is not accessible.
Lua VM failed with no fallback defined, (see -b arg).

Improper API use from Lua script
:
	
Script failure:
  error: /home/adonis/durden/durden/shdrmgmt.lua:77: bad argument #1 to 'shader_uniform' (number expected, got nil)
last path: /
trace:
stack traceback:
	[string "/home/adonis/durden/durden/durden.lua"]:858: in function <[string "/home/adonis/durden/durden/durden.lua"]:855>
	[C]: in function 'shader_uniform'
	/home/adonis/durden/durden/shdrmgmt.lua:77: in function 'set_uniform'
	/home/adonis/durden/durden/shdrmgmt.lua:214: in function 'shader_setup'
	/home/adonis/durden/durden/uiprim/bar.lua:118: in function 'update'
	/home/adonis/durden/durden/uiprim/bar.lua:303: in function 'uiprim_button'
	/home/adonis/durden/durden/uiprim/bar.lua:469: in function 'btn_insert'
	/home/adonis/durden/durden/uiprim/bar.lua:605: in function 'add_button'
	/home/adonis/durden/durden/tiler.lua:691: in function 'tiler_statusbar_build'
	/home/adonis/durden/durden/tiler.lua:5411: in function 'tiler_create'
	[string "/home/adonis/durden/durden/durden.lua"]:85: in function 'wm_alloc_function'
	/home/adonis/durden/durden/display.lua:856: in function 'display_manager_init'
	[string "/home/adonis/durden/durden/durden.lua"]:83: in function <[string "/home/adonis/durden/durden/durden.lua"]:30>
C-entry point:   .

Handing over to recovery script (or shutdown if none present).

version:
	arcan-git-master-0.6.0-pre2-291-g3a81c862-egl-dri-gl21-openal-evdev-luajit51-unknown-linux
	shmif-9223310550170255392
	luaapi-0:11
AL lib: (EE) alc_cleanup: 1 device not closed
```
