### PR TITLE
Expose statusbar background color and alpha to the config

### DIFF
--- a/durden/config.lua
+++ b/durden/config.lua
@@ -277,6 +277,7 @@ return {
 	sbar_sz = 12, -- dynamically recalculated on font changes
 	sbar_textstr = "\\#00ff00 ",
 	sbar_alpha = 0.3,
+	sbar_color = {0, 0, 0},
 	sbar_tspace = 0,
 	sbar_lspace = 0,
 	sbar_dspace = 0,

--- a/durden/menus/global/statusbar.lua
+++ b/durden/menus/global/statusbar.lua
@@ -358,6 +358,36 @@ return {
 		end
 	},
 	{
+		name = "color",
+		label = "Color",
+		kind = "value",
+		description = "Change the statusbar background color",
+		hint = "(r g b)[0..1]",
+		widget = "special:colorpick_r8g8b8",
+		initial = function()
+			local bc = gconfig_get("sbar_color");
+			return string.format("%.0f %.0f %.0f", bc[1], bc[2], bc[3]);
+		end,
+		handler = function(ctx, val)
+			local tbl = suppl_unpack_typestr("fff", val, 0, 255);
+			gconfig_set("sbar_color", tbl);
+			active_display():tile_update();
+		end
+	},
+	{
+		name = "transparency",
+		label = "Transparency",
+		kind = "value",
+		description = "Change the statusbar alpha value",
+		initial = function()
+			return gconfig_get("sbar_alpha");
+		end,
+		handler = function(ctx, val)
+			gconfig_set("sbar_alpha", tonumber(val));
+			active_display():tile_update();
+		end
+	},
+	{
 		name = "visibility",
 		label = "Visibility",
 		kind = "value",

--- a/durden/tiler.lua
+++ b/durden/tiler.lua
@@ -613,6 +613,12 @@ local function tiler_statusbar_update(wm)
 		statush = 0;
 	end
 
+-- Update background color and alpha
+	local r, g, b = unpack(gconfig_get("sbar_color"));
+	local alpha = gconfig_get("sbar_alpha");
+	shader_update_uniform(wm.statusbar.shader, "ui", "col",
+					  	  { r / 255, g / 255, b / 255, alpha});
+
 -- positioning etc. still needs the current size of the statusbar
 	statush = sbar_geth(wm);
 	wm.statusbar:resize(wm.width - pad_l - pad_r, statush);


### PR DESCRIPTION
Hi, first time playing with arcan, durden, lua and glsl. Let me know if I messed up something important.

There's one small issue caused by this PR though. Every time I change the settings I get this message in the terminal (i'm running durden on X11 via SDL)

```
(arcan_video_deleteobject(reference-pass) -- remove rendertarget (tiler_rtdefault)
```