### PR TITLE
proof of concept: implement the  passive mode of the clipboard bridge

### DIFF
--- a/durden/atypes/clipboard.lua
+++ b/durden/atypes/clipboard.lua
@@ -11,10 +11,10 @@ local function clipboard_event(msg, source)
 		return;
 	end
 
-	if (msg and string.len(msg) > 0 and valid_vid(cm, TYPE_FRAMESERVER)) then
+	if (msg and string.len(msg) > 0 and valid_vid(cm.external, TYPE_FRAMESERVER)) then
 		local mode = gconfig_get("clipboard_access");
 		if (mode == "passive" or mode == "full") then
-			message_target(cm.vid, msg);
+			message_target(cm.external, msg);
 		end
 	end
 end

--- a/durden/extevh.lua
+++ b/durden/extevh.lua
@@ -895,6 +895,10 @@ function extevh_apply_atype(wnd, atype, source, stat)
 	wnd.dispatch = table.copy(atbl.dispatch);
 	wnd.labels = table.copy(atbl.labels);
 
+	if (atbl.atype == "clipboard") then
+		atbl.dispatch.registered(wnd, source, stat);
+	end
+
 	wnd.source_audio = (stat and stat.source_audio) or BADID;
 	wnd.atype = atype;
 


### PR DESCRIPTION
this is just a proof of concept and not a real PR since I believe there's a deeper bug which shows up in extevh_default, possibly related to wnd_setup (?), but I didn't have the time to investigate it, yet.

anyway, this kludge shows that presently durden does not correctly implement  the passive mode of the clipboard bridge and shows how it would be possible to run aclip -o -l 0 and get something from durden.